### PR TITLE
Bind write function so we can access ember services in the write override

### DIFF
--- a/addon/services/document.js
+++ b/addon/services/document.js
@@ -5,7 +5,7 @@ export default Ember.Service.extend({
     init() {
         this._super(...arguments);
         let document = get(this, 'document');
-        document.write = get(this, 'write');
+        document.write = get(this, 'write').bind(this);
     },
     document: computed({
         get() {

--- a/blueprints/document-service/files/app/services/document.js
+++ b/blueprints/document-service/files/app/services/document.js
@@ -1,9 +1,11 @@
 import DocumentService from 'ember-disable-document-write/services/document';
 
 export default DocumentService.extend({
+    /*
     init() {
         this._super(...arguments);
     },
+    */
     write(/* content */) {
         // insert any functionality to be executed when document.write is called
     }


### PR DESCRIPTION
If the dev wants to access ember services or properties of the document service they've added, we need to bind to the service scope.

@kellyselden any opinions, or suggestions on alternative patterns?